### PR TITLE
[FIX] 푸드트럭 리스트 반환 시 food_type, menu name 반환

### DIFF
--- a/src/main/java/likelion/scent_yonsei/domain/booth/api/controller/BoothController.java
+++ b/src/main/java/likelion/scent_yonsei/domain/booth/api/controller/BoothController.java
@@ -19,9 +19,10 @@ public class BoothController {
             @RequestParam(defaultValue = "")    String search,
             @RequestParam(defaultValue = "백양로")    String section,
             @RequestParam(defaultValue = "부스")    String category,
-            @RequestParam(defaultValue = "3")   int day
+            @RequestParam(defaultValue = "3")   int day,
+            @RequestParam(required = false, defaultValue = "전체") String foodType
     ) {
-        var resp = boothService.getBooths(search, section, category, day);
+        var resp = boothService.getBooths(search, section, category, day, foodType);
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/likelion/scent_yonsei/domain/booth/api/dto/FoodTruckSummaryDto.java
+++ b/src/main/java/likelion/scent_yonsei/domain/booth/api/dto/FoodTruckSummaryDto.java
@@ -2,8 +2,12 @@ package likelion.scent_yonsei.domain.booth.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public record FoodTruckSummaryDto(
         @JsonProperty("foodTruckId") Long   foodTruckId,
         String name,
-        String photo
+        String photo,
+        @JsonProperty("foodType")        String    foodType,
+        @JsonProperty("menuNames")   List<String> menuNames
 ) {}

--- a/src/main/java/likelion/scent_yonsei/domain/booth/core/FoodTruck.java
+++ b/src/main/java/likelion/scent_yonsei/domain/booth/core/FoodTruck.java
@@ -36,6 +36,9 @@ public class FoodTruck {
     @Column(length = 150)
     private String photo;
 
+    @Column(name = "food_type", nullable = false, length = 10)
+    private String foodType;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -52,11 +55,13 @@ public class FoodTruck {
                      int day,
                      String section,
                      String description,
+                     String foodType,
                      String instagram) {
         this.name = name;
         this.day = day;
         this.section = section;
         this.description = description;
         this.instagram = instagram;
+        this.foodType = foodType;
     }
 }

--- a/src/main/java/likelion/scent_yonsei/domain/booth/core/FoodTruckRepository.java
+++ b/src/main/java/likelion/scent_yonsei/domain/booth/core/FoodTruckRepository.java
@@ -13,14 +13,14 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long> {
       WHERE (:search      IS NULL
              OR t.name        LIKE %:search%
              OR t.description LIKE %:search%)
-        AND (:section IS NULL OR t.section = :section)
         AND t.day = :day
         AND (:category = '전체' OR :category = '푸드트럭')
+        AND (:foodType = '전체' OR t.foodType = :foodType)
     """)
     List<FoodTruck> findFiltered(
             @Param("search")   String search,
-            @Param("section")  String section,
             @Param("day")      int day,
-            @Param("category") String category
+            @Param("category") String category,
+            @Param("foodType") String foodType
     );
 }


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #54 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
푸드트럭 리스트 반환 시 food_type(음식/디저트), 메뉴 이름 반환.
food_type에 따른 결과 필터링(전체/음식/디저트)

## 📚 Reference



### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?